### PR TITLE
[FRONT-0008] - traer certificate_date de la API

### DIFF
--- a/client/src/certificate_preview/components/App/index.js
+++ b/client/src/certificate_preview/components/App/index.js
@@ -3,7 +3,7 @@ import Spinner from '../Spinner';
 import NotFound from '../NotFound';
 import GenericError from '../GenericError';
 import CertificatePreview from '../CertificatePreview';
-import { fetchCertificateData } from '../../utils';
+import { fetchCertificateData, getCertificateIdFromUrl } from '../../utils';
 
 const App = () => {
 	const [isLoading, setIsLoading] = useState(true);
@@ -12,7 +12,8 @@ const App = () => {
 	const [certificateData, setCertificateData] = useState({});
 
 	useEffect(() => {
-		fetchCertificateData()
+		const certificateId = getCertificateIdFromUrl(); 
+		fetchCertificateData(certificateId)
 			.then((response) => {
 				setIsLoading(false);
 				setCertificateData(response);

--- a/client/src/certificate_preview/components/CertificatePreview/index.js
+++ b/client/src/certificate_preview/components/CertificatePreview/index.js
@@ -38,23 +38,13 @@ const CertificatePreview = ({ certificateData }) => {
 						</main>
 						<footer className={styleFlexCenterColumn}>
 							<div className="certificate__footer text-break mt-3">
-								Id de la transaction:
+								Este certificado todavía no figura en la blockchain
 							</div>
-							<div className="certificate__footer text-break text-center">{certificateData.id}</div>
 						</footer>
 					</div>
 				</div>
 			</div>
 
-			<div className="m-3">
-				<a
-					href={`https://etherscan.io/tx/${certificateData.txId}`}
-					target="_blank"
-					rel="noreferrer"
-				>
-					Ver transacción en la blockchain
-				</a>
-			</div>
 			<div className="m-3">
 				<button onClick={() => handleDownload(certificateNode)} type="button" className="btn btn-primary">
 					DESCARGAR
@@ -66,7 +56,7 @@ const CertificatePreview = ({ certificateData }) => {
 
 CertificatePreview.propTypes = {
 	certificateData: PropTypes.shape({
-		id: PropTypes.string.isRequired,
+		id: PropTypes.number.isRequired,
 		username: PropTypes.string.isRequired,
 		first_name: PropTypes.string.isRequired,
 		last_name: PropTypes.string.isRequired,

--- a/client/src/certificate_preview/utils/index.js
+++ b/client/src/certificate_preview/utils/index.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-unused-vars
 const mockedCertificateData = {
 	"id": '0xbed43af4d271362da3b85a370f9226fcde9e78c2c98e2bfd74d6774c2261a3fa',
 	"username": 'Juan Tarufetti',
@@ -11,19 +12,19 @@ const mockedCertificateData = {
 	"event_owner_last_name": 'Varela',
 };
 
-// eslint-disable-next-line no-unused-vars
-const mockedNotFoundResponse = {
-	success: false,
-	status: 404
-};
+export const fetchCertificateData = certificate_id => new Promise((resolve, reject) => {
+	const certificate_details_url = `/courses/certificate_detail/${certificate_id}`;
 
-// eslint-disable-next-line no-unused-vars
-const mockedErrorResponse = {
-	success: false,
-	status: 500
-};
+	fetch(certificate_details_url)
+		.then(response => {
+			if (response.status === 200) return response.json();
+			else reject({ status: response.status });
+		})
+		.then(resolve)
+		.catch(reason => {
+			console.error('TESTSSSS', reason); // eslint-disable-line no-console
+			reject({ status: 123456 });
+		})
+	});
 
-// eslint-disable-next-line import/prefer-default-export
-export const fetchCertificateData = () => new Promise((resolve) => {
-	setTimeout(() => resolve(mockedCertificateData), 900);
-});
+export const getCertificateIdFromUrl = () => window.location.href.split('certificate_preview/')[1];


### PR DESCRIPTION
Cómo testear.

1. Buildear el frontend: ir al directorio `client` y correr el comando `npm run build` .
2. Buildear el resto de la app: volver al directorio raiz y correr el comando `docker-compose build` .
3. Levantar la aplicación: correr el comando `docker-compose up` .
4. Navegar por la app hasta la página de certificate_preview.
5. Confirmar que el frontend muestra los datos correctos del certificado correspondiente.
6. Si el certificado no existe en la DB, muestra un mensaje de 404.
7. También hay un mensaje genérico de error para todos los demás status codes.