### PR TITLE
FRONT-0010: mejorar feature de descargar certificado

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "main": "config.js",
   "dependencies": {
     "bootstrap": "^4.6.0",
-    "dom-to-image": "^2.6.0",
+    "html2canvas": "^1.0.0-rc.7",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-bootstrap": "^1.4.3",

--- a/client/src/certificate_preview/components/CertificatePreview/index.js
+++ b/client/src/certificate_preview/components/CertificatePreview/index.js
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
-import domtoimage from 'dom-to-image';
+import html2canvas from 'html2canvas';
 import logo from './academia_blockchain_logo.png';
 import './index.sass';
 
@@ -8,19 +8,19 @@ const CertificatePreview = ({ certificateData }) => {
 	const certificateNode = useRef(null);
 	const styleFlexCenterColumn = 'd-flex justify-content-center align-items-center flex-column';
 	const handleDownload = (ref) => {
-		domtoimage.toJpeg(ref.current)
-			.then((dataUrl) => {
-				const link = document.createElement('a');
-				link.download = 'CERTIFICADO_ACBC.jpeg';
-				link.href = dataUrl;
-				link.click();
-			});
+		html2canvas(ref.current).then((canvas) => {
+			const link = document.createElement('a');
+			link.setAttribute('download', 'ACBC_CERTIFICADO.png');
+			link.setAttribute('href', canvas.toDataURL('image/png').replace('image/png', 'image/octet-stream'));
+			link.click();
+			link.remove();
+		});
 	};
 
 	return (
 		<div className={styleFlexCenterColumn}>
-			<div ref={certificateNode} aria-label="Vista previa del certificado" className="w-100">
-				<div className="certificate__border">
+			<div aria-label="Vista previa del certificado" className="w-100">
+				<div ref={certificateNode} className="certificate__border">
 					<div className="certificate__container">
 						<header className="certificate__header p-1">
 							<div className="certificate__logo-container">

--- a/client/src/certificate_preview/components/CertificatePreview/index.sass
+++ b/client/src/certificate_preview/components/CertificatePreview/index.sass
@@ -61,7 +61,7 @@ $layout-breakpoint-medium: 1020px
   @media (min-width: $layout-breakpoint-small)
     &__border
       width: 80%
-      max-width: 1280px
+      max-width: 1140px
       margin: 0 auto
 
     &__logo-container


### PR DESCRIPTION
**Problema**: al descargar la imagen del certificado, la imagen se descarga mal, los estilos son distintos.

**Resultados esperados**: que la imagen se descargue bien y los estilos.

**Solución**: 

- Cambié la librería `dom-to-image`  por la `html2canvas` y actualicé la función.
- También puse un max-witdh del certificado porque a veces queda muy alargada y poco alta.
